### PR TITLE
Add additional check for scalar values.

### DIFF
--- a/src/Infrastructure/Doctrine/Type/AbstractIdType.php
+++ b/src/Infrastructure/Doctrine/Type/AbstractIdType.php
@@ -13,6 +13,10 @@ abstract class AbstractIdType extends IntegerType
 {
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
+        if (is_int($value)) {
+            return $value;
+        }
+
         if (!$value instanceof Id) {
             throw ConversionException::conversionFailedInvalidType(
                 $value,

--- a/src/Infrastructure/Doctrine/Type/AbstractUuidType.php
+++ b/src/Infrastructure/Doctrine/Type/AbstractUuidType.php
@@ -17,6 +17,10 @@ abstract class AbstractUuidType extends GuidType
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
+        if (is_string($value)) {
+            return $value;
+        }
+
         if (!$value instanceof Uuid) {
             throw ConversionException::conversionFailedInvalidType(
                 $value,

--- a/tests/Unit/Infrastructure/Doctrine/Type/AbstractIdTypeTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/Type/AbstractIdTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GeekCell\DddBundle\Tests\Unit\Infrastructure\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
 use GeekCell\Ddd\Domain\ValueObject\Id;
 use GeekCell\DddBundle\Infrastructure\Doctrine\Type\AbstractIdType;
 use Mockery;
@@ -47,6 +48,33 @@ class AbstractIdTypeTest extends TestCase
 
         // Then
         $this->assertSame($intId, $result);
+    }
+
+    public function testConvertToDatabaseValueScalar(): void
+    {
+        // Given
+        $intId = 42;
+        $type = new FooIdType();
+        $platform = Mockery::mock(AbstractPlatform::class);
+
+        // When
+        $result = $type->convertToDatabaseValue($intId, $platform);
+
+        // Then
+        $this->assertSame($intId, $result);
+    }
+
+    public function testConvertToDatabaseValueInvalidType(): void
+    {
+        // Given
+        $type = new FooIdType();
+        $platform = Mockery::mock(AbstractPlatform::class);
+
+        // Then
+        $this->expectException(ConversionException::class);
+
+        // When
+        $type->convertToDatabaseValue('foo', $platform);
     }
 
     public function testConvertToPhpValue(): void

--- a/tests/Unit/Infrastructure/Doctrine/Type/AbstractUuidTypeTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/Type/AbstractUuidTypeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GeekCell\DddBundle\Tests\Unit\Infrastructure\Doctrine\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
 use GeekCell\Ddd\Domain\ValueObject\Uuid;
 use GeekCell\DddBundle\Infrastructure\Doctrine\Type\AbstractUuidType;
 use Mockery;
@@ -29,10 +30,12 @@ class FooUuidType extends AbstractUuidType
 
 class AbstractUuidTypeTest extends TestCase
 {
+    private const UUID_STRING = '00000000-0000-0000-0000-000000000000';
+
     public function testConvertToDatabaseValue(): void
     {
         // Given
-        $uuidString = '00000000-0000-0000-0000-000000000000';
+        $uuidString = self::UUID_STRING;
         $platform = Mockery::mock(AbstractPlatform::class);
         $type = new FooUuidType();
 
@@ -46,10 +49,37 @@ class AbstractUuidTypeTest extends TestCase
         $this->assertSame($uuidString, $result);
     }
 
+    public function testConvertToDatabaseValueScalar(): void
+    {
+        // Given
+        $uuidString = self::UUID_STRING;
+        $platform = Mockery::mock(AbstractPlatform::class);
+        $type = new FooUuidType();
+
+        // When
+        $result = $type->convertToDatabaseValue($uuidString, $platform);
+
+        // Then
+        $this->assertSame($uuidString, $result);
+    }
+
+    public function testConvertToDatabaseValueInvalidType(): void
+    {
+        // Given
+        $platform = Mockery::mock(AbstractPlatform::class);
+        $type = new FooUuidType();
+
+        // Then
+        $this->expectException(ConversionException::class);
+
+        // When
+        $type->convertToDatabaseValue(42, $platform);
+    }
+
     public function testConvertToPhpValue(): void
     {
         // Given
-        $uuidString = '00000000-0000-0000-0000-000000000000';
+        $uuidString = self::UUID_STRING;
         $platform = Mockery::mock(AbstractPlatform::class);
         $type = new FooUuidType();
 


### PR DESCRIPTION
The `convertToDatabaseValue` method does indeed also receive scalar values.