### PR TITLE
Update FacadeSetupSubscriber.php

### DIFF
--- a/src/EventSubscriber/FacadeSetupSubscriber.php
+++ b/src/EventSubscriber/FacadeSetupSubscriber.php
@@ -17,7 +17,7 @@ class FacadeSetupSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [


### PR DESCRIPTION
Fix deprecation message `User Deprecated: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "GeekCell\DddBundle\EventSubscriber\FacadeSetupSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.`