### PR TITLE
Enable custom doctrine types to handle `null` values

### DIFF
--- a/src/Infrastructure/Doctrine/Type/AbstractIdType.php
+++ b/src/Infrastructure/Doctrine/Type/AbstractIdType.php
@@ -17,6 +17,10 @@ abstract class AbstractIdType extends IntegerType
             return $value;
         }
 
+        if ($value === null) {
+            return null;
+        }
+
         if (!$value instanceof Id) {
             throw ConversionException::conversionFailedInvalidType(
                 $value,
@@ -30,6 +34,10 @@ abstract class AbstractIdType extends IntegerType
 
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if ($value === null) {
+            return null;
+        }
+
         $idType = $this->getIdType();
         if (!is_subclass_of($idType, Id::class)) {
             throw ConversionException::conversionFailedUnserialization(

--- a/src/Infrastructure/Doctrine/Type/AbstractUuidType.php
+++ b/src/Infrastructure/Doctrine/Type/AbstractUuidType.php
@@ -21,6 +21,10 @@ abstract class AbstractUuidType extends GuidType
             return $value;
         }
 
+        if ($value === null) {
+            return null;
+        }
+
         if (!$value instanceof Uuid) {
             throw ConversionException::conversionFailedInvalidType(
                 $value,
@@ -38,6 +42,10 @@ abstract class AbstractUuidType extends GuidType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
+        if ($value === null) {
+            return null;
+        }
+
         $idType = $this->getIdType();
         if (!is_subclass_of($idType, Uuid::class)) {
             throw ConversionException::conversionFailedUnserialization(

--- a/tests/Unit/Infrastructure/Doctrine/PaginatorTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/PaginatorTest.php
@@ -9,7 +9,7 @@ use GeekCell\DddBundle\Infrastructure\Doctrine\Paginator as DoctrinePaginator;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
-class DoctrinePaginatorTest extends TestCase
+class PaginatorTest extends TestCase
 {
     /** @var OrmPaginator|Mockery\MockInterface */
     private mixed $ormPaginatorMock;

--- a/tests/Unit/Infrastructure/Doctrine/Type/AbstractIdTypeTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/Type/AbstractIdTypeTest.php
@@ -77,6 +77,19 @@ class AbstractIdTypeTest extends TestCase
         $type->convertToDatabaseValue('foo', $platform);
     }
 
+    public function testConvertToDatabaseValueNull(): void
+    {
+        // Given
+        $type = new FooIdType();
+        $platform = Mockery::mock(AbstractPlatform::class);
+
+        // When
+        $result = $type->convertToDatabaseValue(null, $platform);
+
+        // Then
+        $this->assertNull($result);
+    }
+
     public function testConvertToPhpValue(): void
     {
         // Given
@@ -90,5 +103,18 @@ class AbstractIdTypeTest extends TestCase
         // Then
         $this->assertInstanceOf(FooId::class, $result);
         $this->assertSame($intId, $result->getValue());
+    }
+
+    public function testConvertToPhpValueNull(): void
+    {
+        // Given
+        $type = new FooIdType();
+        $platform = Mockery::mock(AbstractPlatform::class);
+
+        // When
+        $result = $type->convertToPHPValue(null, $platform);
+
+        // Then
+        $this->assertNull($result);
     }
 }

--- a/tests/Unit/Infrastructure/Doctrine/Type/AbstractUuidTypeTest.php
+++ b/tests/Unit/Infrastructure/Doctrine/Type/AbstractUuidTypeTest.php
@@ -63,6 +63,19 @@ class AbstractUuidTypeTest extends TestCase
         $this->assertSame($uuidString, $result);
     }
 
+    public function testConvertToDatabaseValueNull(): void
+    {
+        // Given
+        $platform = Mockery::mock(AbstractPlatform::class);
+        $type = new FooUuidType();
+
+        // When
+        $result = $type->convertToDatabaseValue(null, $platform);
+
+        // Then
+        $this->assertNull($result);
+    }
+
     public function testConvertToDatabaseValueInvalidType(): void
     {
         // Given
@@ -89,5 +102,18 @@ class AbstractUuidTypeTest extends TestCase
         // Then
         $this->assertInstanceOf(FooUuid::class, $result);
         $this->assertSame($uuidString, $result->getValue());
+    }
+
+    public function testConvertToPhpValueNull(): void
+    {
+        // Given
+        $platform = Mockery::mock(AbstractPlatform::class);
+        $type = new FooUuidType();
+
+        // When
+        $result = $type->convertToPHPValue(null, $platform);
+
+        // Then
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
Currently the doctrine custom types do not handle `null` values and cause applications that rely on nullable values to break.

This PR implements this functionality + adds tests