### PR TITLE
fix: logic to throw first wrapped exception in messenger busses

### DIFF
--- a/src/Infrastructure/Messenger/CommandBus.php
+++ b/src/Infrastructure/Messenger/CommandBus.php
@@ -25,7 +25,12 @@ class CommandBus implements CommandBusInterface
             return $this->handle($command);
         } catch (HandlerFailedException $e) {
             $exceptions = $e->getWrappedExceptions();
-            throw $exceptions[0];
+            $first = array_shift($exceptions);
+            if ($first) {
+                throw $first;
+            }
+
+            throw $e;
         }
     }
 }

--- a/src/Infrastructure/Messenger/QueryBus.php
+++ b/src/Infrastructure/Messenger/QueryBus.php
@@ -25,7 +25,12 @@ class QueryBus implements QueryBusInterface
             return $this->handle($query);
         } catch (HandlerFailedException $e) {
             $exceptions = $e->getWrappedExceptions();
-            throw $exceptions[0];
+            $first = array_shift($exceptions);
+            if ($first) {
+                throw $first;
+            }
+
+            throw $e;
         }
     }
 }

--- a/tests/Unit/Infrastructure/Messenger/QueryBusTest.php
+++ b/tests/Unit/Infrastructure/Messenger/QueryBusTest.php
@@ -5,22 +5,29 @@ declare(strict_types=1);
 namespace GeekCell\DddBundle\Tests\Unit\Infrastructure\Messenger;
 
 use GeekCell\Ddd\Contracts\Application\Query;
+use GeekCell\DddBundle\Infrastructure\Messenger\CommandBus;
 use GeekCell\DddBundle\Infrastructure\Messenger\QueryBus;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 
-/**
- * Test fixture for QueryBus.
- */
 class TestQuery implements Query
 {
 }
 
-/**
- * Test fixture for CommandBus.
- */
+class ThrowingQueryHandler
+{
+    public function __construct(private readonly \Exception $exceptionToThrow)
+    {
+    }
+
+    public function __invoke(TestQuery $command): mixed
+    {
+        throw $this->exceptionToThrow;
+    }
+}
+
 class TestQueryHandler
 {
     public function __invoke(TestQuery $query): mixed
@@ -45,6 +52,23 @@ class QueryBusTest extends TestCase
 
         // Then
         $this->assertSame(TestQuery::class, $result);
+    }
+
+    public function testDispatchFailsAndRethrowsException(): void
+    {
+        // Given
+        $expectedException = new \Exception('Not good enough');
+        $bus = $this->createMessageBus(
+            TestQuery::class,
+            new ThrowingQueryHandler($expectedException)
+        );
+        $commandBus = new QueryBus($bus);
+
+        // Then
+        $this->expectExceptionObject($expectedException);
+
+        // When
+        $commandBus->dispatch(new TestQuery());
     }
 
     private function createMessageBus(

--- a/tests/Unit/Infrastructure/Messenger/QueryBusTest.php
+++ b/tests/Unit/Infrastructure/Messenger/QueryBusTest.php
@@ -22,7 +22,7 @@ class ThrowingQueryHandler
     {
     }
 
-    public function __invoke(TestQuery $command): mixed
+    public function __invoke(TestQuery $query): mixed
     {
         throw $this->exceptionToThrow;
     }


### PR DESCRIPTION
In https://github.com/geekcell/ddd-symfony-bundle/pull/46 the `getNestedExceptions` call was replaced with `getWrappedExceptions`, however the returned array from `getWrappedExceptions` is an associate array where the exception name is the key, previously the array was just a list.

This PR fixes the behaviour so that we `array_shift` off the first exception from the wrapped exceptions array and throw it if it's thruthy. Otherwise throw the `HandlerFailedException` itself